### PR TITLE
Add optional configurations `external_server_host` and `external_server_port`

### DIFF
--- a/src/main/kotlin/com/awareframework/micro/WebsocketVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/WebsocketVerticle.kt
@@ -49,14 +49,28 @@ class WebsocketVerticle : AbstractVerticle() {
 
             websocket = server
           }
-          .listen(serverConfig.getInteger("websocket_port")) {
+          .listen(getExternalWebSocketServerPort(serverConfig)) {
             if (it.failed()) {
               println("Failed to initialise websocket server ${it.cause().message}")
             } else {
-              println("AWARE Micro Websocket server: ws://${URL(serverConfig.getString("server_host")).host}:${serverConfig.getInteger("websocket_port")}")
+              println("AWARE Micro Websocket server: ws://${getExternalWebSocketServerHost(serverConfig)}:${getExternalWebSocketServerPort(serverConfig)}")
             }
           }
       }
     }
+  }
+
+  private fun getExternalWebSocketServerHost(serverConfig: JsonObject): String {
+    if (serverConfig.containsKey("external_server_host")) {
+      return URL(serverConfig.getString("external_server_host")).host
+    }
+    return URL(serverConfig.getString("server_host")).host
+  }
+
+  private fun getExternalWebSocketServerPort(serverConfig: JsonObject): Int {
+    if (serverConfig.containsKey("external_websocket_port")) {
+      return serverConfig.getInteger("external_websocket_port")
+    }
+    return serverConfig.getInteger("websocket_port")
   }
 }


### PR DESCRIPTION
Server maintainers often want to run the main aware-micro process as the backend of
reverse proxies (such as Nginx), or load balancers (such as Amazon ALB).

But, the existing configurations `server_host` and `server_port` are used both for
listening as the main aware-micro process, and showing for users/logs as public URLs.

It adds new optional configurations `external_server_host` and `external_server_port`
to split listening and showing.

----

The configurations would be, for example, like:

```
    // The Java Vert.x process listens for 127.0.0.1 at 8080 without SSL/TLS.
    "server_host" : "http://localhost",
    "server_port" : 8080,

    // Another reverse proxy (e.g. Nginx) process would be configured to listen
    // for 0.0.0.0 at 443 with resolving SSL/TLS to forward to localhost:8080.
    "external_server_host": "https://aware.example.com", 
    "external_server_port": 443,
```