### PR TITLE
Enable logging with Logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext {
 
 application {
   mainClassName = 'io.vertx.core.Launcher'
+  applicationDefaultJvmArgs = ['-DlogLevel=INFO']
 }
 
 
@@ -45,7 +46,9 @@ dependencies {
   implementation "io.vertx:vertx-lang-kotlin:$vertxVersion"
   implementation "io.vertx:vertx-mqtt:$vertxVersion"
   implementation "io.vertx:vertx-web-templ-pebble:$vertxVersion"
-  implementation "org.slf4j:slf4j-nop:1.7.25"
+  implementation "org.slf4j:slf4j-api:1.7.36"
+  implementation "ch.qos.logback:logback-classic:1.2.11"
+  implementation "ch.qos.logback:logback-core:1.2.11"
   implementation "io.vertx:vertx-core:$vertxVersion"
 }
 

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,6 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+ch.qos.logback:logback-classic:1.2.11=compileClasspath,runtimeClasspath
+ch.qos.logback:logback-core:1.2.11=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.13.2=compileClasspath,runtimeClasspath
 com.fasterxml.jackson:jackson-bom:2.13.2=compileClasspath,runtimeClasspath
 com.hazelcast:hazelcast:4.2.2=compileClasspath,runtimeClasspath
@@ -45,7 +47,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31=compileClasspath,runtimeClasspath
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31=compileClasspath,runtimeClasspath
 org.jetbrains.kotlin:kotlin-stdlib:1.5.31=compileClasspath,runtimeClasspath
 org.jetbrains:annotations:13.0=compileClasspath,runtimeClasspath
-org.slf4j:slf4j-api:1.7.25=compileClasspath,runtimeClasspath
-org.slf4j:slf4j-nop:1.7.25=compileClasspath,runtimeClasspath
+org.slf4j:slf4j-api:1.7.36=compileClasspath,runtimeClasspath
 org.unbescape:unbescape:1.1.6.RELEASE=compileClasspath,runtimeClasspath
 empty=

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS Z} [%level] (%thread\) %logger - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- DEBUG logs by Netty are noisy. -->
+  <logger name="io.netty" level="INFO"/>
+
+  <root level="${logLevel:-INFO}">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Logging often helps server operators/maintainers. Logs including the date/time, the class where it is logged, the thread, and else, would help investigation when something happens.

In aware-micro, logging (from Vert.x and libarires) is disabled by `slf4j-nop`, and logging from aware-micro is done by `println` without metadata like date/time.

This pull-request enables logging with Logback. It disables debug logs from `io.netty` as I imagined the noisy logs from `io.netty` was the reason of `log4j-nop`. (Yeah, Netty's logs are so noisy...)

By disabling `io.netty`, the logs at startup would be like below -- not so noisy. What do you think?

```
2022-08-19 16:26:18.581 +0900 [INFO] (main) io.vertx.core.impl.launcher.commands.Watcher - Watched paths: [/home/user/aware-micro/./src/main/kotlin]
2022-08-19 16:26:18.584 +0900 [INFO] (main) io.vertx.core.impl.launcher.commands.Watcher - Starting the vert.x application in redeploy mode
Starting vert.x application...
5cdf0903-b322-4d07-aa06-8e63a4ae64e0-redeploy
AWARE Micro initializing...
AWARE Micro API at http://localhost:8080
AWARE Micro Websocket server: ws://localhost:8081
2022-08-19 16:26:19.415 +0900 [INFO] (vert.x-eventloop-thread-0) io.vertx.core.impl.launcher.commands.VertxIsolatedDeployer - Succeeded in deploying verticle
```

If it's okay for you, we may want to replace `println` to logging later on.