### PR TITLE
Fix the "start" and "end" parameters in "query"

### DIFF
--- a/src/main/kotlin/com/awareframework/micro/MainVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/MainVerticle.kt
@@ -227,8 +227,8 @@ class MainVerticle : AbstractVerticle() {
                 val requestData = JsonObject()
                   .put("table", route.request().getParam("table"))
                   .put("device_id", route.request().getFormAttribute("device_id"))
-                  .put("start", route.request().getFormAttribute("start"))
-                  .put("end", route.request().getFormAttribute("end"))
+                  .put("start", route.request().getFormAttribute("start").toDouble())
+                  .put("end", route.request().getFormAttribute("end").toDouble())
 
                 eventBus.request<JsonArray>("getData", requestData) { response ->
                   if (response.succeeded()) {


### PR DESCRIPTION
I had a quick test with the `query` endpoint manually, and it was not working.

`HttpServerRequest#getFormAttribute()` always returns `String`, but `JsonObject#getDouble` expects it's a `Number`, not a `String`.

https://vertx.io/docs/4.3.4/apidocs/io/vertx/core/http/HttpServerRequest.html#getFormAttribute-java.lang.String-

https://github.com/denzilferreira/aware-micro/blob/f02e37c2af530f779330656ff039079782511081/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt#L94-L95