### PR TITLE
Fix enumerating "timestamps" in "delete"

### DIFF
--- a/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
@@ -166,7 +166,7 @@ class MySQLVerticle : AbstractVerticle() {
         val timestamps = mutableListOf<Double>()
         for (i in 0 until data.size()) {
           val entry = data.getJsonObject(i)
-          timestamps.plus(entry.getDouble("timestamp"))
+          timestamps.add(entry.getDouble("timestamp"))
         }
 
         val deleteBatch =

--- a/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
@@ -165,7 +165,7 @@ class PostgresVerticle : AbstractVerticle() {
         val timestamps = mutableListOf<Double>()
         for (i in 0 until data.size()) {
           val entry = data.getJsonObject(i)
-          timestamps.plus(entry.getDouble("timestamp"))
+          timestamps.add(entry.getDouble("timestamp"))
         }
 
         val deleteBatch =


### PR DESCRIPTION
I had a quick test with the `delete` endpoint manually, and it was not working.

Kotlin `MutableList`'s `plus` does not update the list by itself, but returns a new list with a new element.

Here, it looks expecting that the list is updated by itself. Then, replacing `plus` to `add`.

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-list/