### PR TITLE
Upgrade the Gradle Shadow plugin to 7.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.jetbrains.kotlin.jvm' version '1.5.31'
   id 'application'
-  id 'com.github.johnrengelman.shadow' version '5.0.0'
+  id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 group = 'com.awareframework'


### PR DESCRIPTION
I upgraded its Gradle wrapper to 7 in #9, but I was not aware that the Shadow plugin 5.0.0 did not work with Gradle 7.

https://github.com/johnrengelman/shadow

I had to upgrade the Shadow plugin as well.