### PR TITLE
Set SSL Certificate only when configured

### DIFF
--- a/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
@@ -266,10 +266,14 @@ class MySQLVerticle : AbstractVerticle() {
       }
       "prefer", "preferred" -> {
         options.setSslMode(SslMode.PREFERRED)
-        options.setPemTrustOptions(PemTrustOptions().addCertPath(serverConfig.getString("database_ssl_path_ca_cert_pem")))
-        options.setPemKeyCertOptions(PemKeyCertOptions()
-          .setKeyPath(serverConfig.getString("database_ssl_path_client_key_pem"))
-          .setCertPath(serverConfig.getString("database_ssl_path_client_cert_pem")))
+        if (serverConfig.containsKey("database_ssl_path_ca_cert_pem")) {
+          options.setPemTrustOptions(PemTrustOptions().addCertPath(serverConfig.getString("database_ssl_path_ca_cert_pem")))
+          if (serverConfig.containsKey("database_ssl_path_client_key_pem")) {
+            options.setPemKeyCertOptions(PemKeyCertOptions()
+                .setKeyPath(serverConfig.getString("database_ssl_path_client_key_pem"))
+                .setCertPath(serverConfig.getString("database_ssl_path_client_cert_pem")))
+          }
+        }
       }
     }
   }

--- a/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
@@ -274,10 +274,14 @@ class PostgresVerticle : AbstractVerticle() {
       }
       "prefer", "preferred" -> {
         options.setSslMode(SslMode.PREFER)
-        options.setPemTrustOptions(PemTrustOptions().addCertPath(serverConfig.getString("database_ssl_path_ca_cert_pem")))
-        options.setPemKeyCertOptions(PemKeyCertOptions()
-          .setKeyPath(serverConfig.getString("database_ssl_path_client_key_pem"))
-          .setCertPath(serverConfig.getString("database_ssl_path_client_cert_pem")))
+        if (serverConfig.containsKey("database_ssl_path_ca_cert_pem")) {
+          options.setPemTrustOptions(PemTrustOptions().addCertPath(serverConfig.getString("database_ssl_path_ca_cert_pem")))
+          if (serverConfig.containsKey("database_ssl_path_client_key_pem")) {
+            options.setPemKeyCertOptions(PemKeyCertOptions()
+                .setKeyPath(serverConfig.getString("database_ssl_path_client_key_pem"))
+                .setCertPath(serverConfig.getString("database_ssl_path_client_cert_pem")))
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The database certs are not always mandatory even when the SSL mode is preferred. This pull request sets the certs only when specified.