### PR TITLE
Ignore insertData when data is empty

### DIFF
--- a/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
@@ -218,6 +218,10 @@ class MySQLVerticle : AbstractVerticle() {
    * Insert batch of data into database table
    */
   fun insertData(table: String, device_id: String, data: JsonArray) {
+    if (data.size() <= 0) {
+      return
+    }
+
     createTable(table)
       .onSuccess { _ ->
         sqlClient.getConnection { connectionResult ->

--- a/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/MySQLVerticle.kt
@@ -218,7 +218,7 @@ class MySQLVerticle : AbstractVerticle() {
    * Insert batch of data into database table
    */
   fun insertData(table: String, device_id: String, data: JsonArray) {
-    if (data.size() <= 0) {
+    if (data.isEmpty()) {
       return
     }
 

--- a/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
@@ -225,6 +225,10 @@ class PostgresVerticle : AbstractVerticle() {
    * Insert batch of data into database table
    */
   fun insertData(table: String, device_id: String, data: JsonArray) {
+    if (data.size() <= 0) {
+      return
+    }
+
     createTable(table)
       .onSuccess { _ ->
         sqlClient.getConnection { connectionResult ->

--- a/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
+++ b/src/main/kotlin/com/awareframework/micro/PostgresVerticle.kt
@@ -225,7 +225,7 @@ class PostgresVerticle : AbstractVerticle() {
    * Insert batch of data into database table
    */
   fun insertData(table: String, device_id: String, data: JsonArray) {
-    if (data.size() <= 0) {
+    if (data.isEmpty()) {
       return
     }
 


### PR DESCRIPTION
Just a workaround for a corner case. If a request comes with empty data `[]`, it fails.

I believe empty data would not come from the real aware-light/aware-client. Just wanted this not to fail when I test the server with `curl`.